### PR TITLE
Add AGENTS.md for dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+## Cursor Cloud specific instructions
+
+This is a small Node.js proof-of-concept security scanner ("BugBot") that scans Terraform and Kubernetes config files for misconfigurations.
+
+### Running the application
+
+```bash
+node bot/bugbot.js
+```
+
+This scans `terraform/main.tf` and `k8s/deployment.yaml`, writes results to `report/findings.json`, and optionally posts to Slack if `SLACK_WEBHOOK` env var is set.
+
+### Key notes
+
+- The project uses **Node.js** (CI targets Node 18; any Node >= 18 works) with **npm** as the package manager.
+- The only runtime dependency is `axios` (for optional Slack webhook posting).
+- There is no dev server or build step — the bot is a single-run CLI script.
+- The `test` script in `package.json` is a placeholder (`exit 1`); there are no automated tests.
+- The `SLACK_WEBHOOK` environment variable is optional; the bot runs fine without it (logs "No Slack webhook found").


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for development environment setup.

## What was done

- Set up the development environment for this Node.js security scanner PoC
- Verified `npm install` installs dependencies successfully (only dependency: `axios`)
- Ran `node bot/bugbot.js` and confirmed the scanner works end-to-end:
  - Scans `terraform/main.tf` and `k8s/deployment.yaml`
  - Correctly detects the open security group (`0.0.0.0/0`) in the Terraform config
  - Writes findings to `report/findings.json`
  - Gracefully handles missing `SLACK_WEBHOOK` env var

## Files changed

- **`AGENTS.md`** (new): Documents how to run the application, key dev notes, and non-obvious caveats for future cloud agents.

## Run output

[bugbot_run_output.log](https://cursor.com/agents/bc-cd7453d4-7790-4a91-89eb-e281aed04132/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbugbot_run_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd7453d4-7790-4a91-89eb-e281aed04132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd7453d4-7790-4a91-89eb-e281aed04132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

