### PR TITLE
Fix false negative in Kubernetes limits scan

### DIFF
--- a/bot/bugbot.js
+++ b/bot/bugbot.js
@@ -17,7 +17,9 @@ if (tf.includes("0.0.0.0/0")) {
 
 // Kubernetes scan
 const k8s = fs.readFileSync("./k8s/deployment.yaml", "utf-8");
-if (!k8s.includes("limits")) {
+// Ignore YAML comments so the check only looks at config keys.
+const k8sWithoutComments = k8s.replace(/^\s*#.*$/gm, "");
+if (!/^\s*limits\s*:/m.test(k8sWithoutComments)) {
   findings.push({
     file: "deployment.yaml",
     issue: "Missing resource limits",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Ignore YAML comments when checking for Kubernetes `limits` keys.
- Prevent false negatives where comment text contains the word `limits`.

## Why
Recent PR inspection showed scanner output changed based on comment text, not actual manifest fields.

## Scope
- Small one-file update in `bot/bugbot.js`.

## Validation plan
- Reproduce pre-fix false negative on `master`.
- Run scanner with this branch and verify `Missing resource limits` is now reported.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-088263da-5ffc-4c0f-82af-d4d5f0bcdbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-088263da-5ffc-4c0f-82af-d4d5f0bcdbb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of Kubernetes resource limits scanning by ignoring YAML comment lines. This prevents false positives where commented configuration text would previously be incorrectly flagged as missing resource limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->