### PR TITLE
feat(terraform): add reusable AWS module library and example stack

### DIFF
--- a/examples/.terraform.lock.hcl
+++ b/examples/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 5.0.0, ~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -14,14 +14,13 @@ provider "aws" {
 }
 
 locals {
-  name = "${var.environment}-${var.project_name}"
+  name = var.name
 
   common_tags = merge(
     var.common_tags,
     {
-      Environment = var.environment
-      Project     = var.project_name
-      ManagedBy   = "terraform"
+      NamePrefix = var.name
+      ManagedBy  = "terraform"
     }
   )
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,0 +1,140 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  name = "${var.environment}-${var.project_name}"
+
+  common_tags = merge(
+    var.common_tags,
+    {
+      Environment = var.environment
+      Project     = var.project_name
+      ManagedBy   = "terraform"
+    }
+  )
+}
+
+module "vpc" {
+  source = "../modules/vpc"
+
+  name                 = local.name
+  vpc_cidr             = var.vpc_cidr
+  azs                  = var.availability_zones
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+
+  tags = local.common_tags
+}
+
+resource "aws_security_group" "ecs_service" {
+  name        = "${local.name}-ecs-sg"
+  description = "Security group for ECS service tasks"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description = "Application port"
+    from_port   = var.container_port
+    to_port     = var.container_port
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_app_ingress_cidrs
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "${local.name}-ecs-sg" })
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${local.name}-rds-sg"
+  description = "Security group for PostgreSQL"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    description     = "PostgreSQL from ECS tasks"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.ecs_service.id]
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, { Name = "${local.name}-rds-sg" })
+}
+
+module "ecs" {
+  source = "../modules/ecs"
+
+  name                   = local.name
+  container_name         = "${local.name}-app"
+  container_image        = var.container_image
+  container_port         = var.container_port
+  desired_count          = var.desired_count
+  cpu                    = var.task_cpu
+  memory                 = var.task_memory
+  assign_public_ip       = false
+  subnet_ids             = module.vpc.private_subnet_ids
+  security_group_ids     = [aws_security_group.ecs_service.id]
+  execution_role_arn     = var.ecs_execution_role_arn
+  task_role_arn          = var.ecs_task_role_arn
+  enable_execute_command = var.enable_execute_command
+
+  environment = {
+    DB_HOST = module.rds.db_address
+    DB_PORT = tostring(module.rds.db_port)
+    DB_NAME = module.rds.db_name
+    DB_USER = module.rds.db_username
+  }
+
+  tags = local.common_tags
+}
+
+module "rds" {
+  source = "../modules/rds"
+
+  name                    = local.name
+  identifier              = "${local.name}-postgres"
+  engine_version          = var.db_engine_version
+  instance_class          = var.db_instance_class
+  allocated_storage       = var.db_allocated_storage
+  max_allocated_storage   = var.db_max_allocated_storage
+  db_name                 = var.db_name
+  username                = var.db_username
+  password                = var.db_password
+  port                    = 5432
+  subnet_ids              = module.vpc.private_subnet_ids
+  security_group_ids      = [aws_security_group.rds.id]
+  multi_az                = var.db_multi_az
+  backup_retention_period = var.db_backup_retention_period
+  deletion_protection     = var.db_deletion_protection
+  skip_final_snapshot     = var.db_skip_final_snapshot
+  publicly_accessible     = var.db_publicly_accessible
+
+  tags = local.common_tags
+}

--- a/examples/outputs.tf
+++ b/examples/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  description = "Provisioned VPC ID."
+  value       = module.vpc.vpc_id
+}
+
+output "ecs_cluster_arn" {
+  description = "ECS cluster ARN."
+  value       = module.ecs.cluster_arn
+}
+
+output "ecs_service_name" {
+  description = "ECS service name."
+  value       = module.ecs.service_name
+}
+
+output "rds_endpoint" {
+  description = "RDS PostgreSQL endpoint."
+  value       = module.rds.db_address
+}
+
+output "rds_port" {
+  description = "RDS PostgreSQL port."
+  value       = module.rds.db_port
+}

--- a/examples/variables.tf
+++ b/examples/variables.tf
@@ -1,0 +1,171 @@
+variable "aws_region" {
+  description = "AWS region for all resources."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name" {
+  description = "Base name prefix for resource naming."
+  type        = string
+  default     = "platform"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets."
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24"]
+}
+
+variable "availability_zones" {
+  description = "Availability Zones to deploy across."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+}
+
+variable "container_image" {
+  description = "Container image to run in ECS."
+  type        = string
+  default     = "public.ecr.aws/nginx/nginx:stable"
+}
+
+variable "container_port" {
+  description = "Container and service port."
+  type        = number
+  default     = 80
+}
+
+variable "allowed_app_ingress_cidrs" {
+  description = "CIDRs allowed to access the ECS application port."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "desired_count" {
+  description = "Desired number of ECS tasks."
+  type        = number
+  default     = 1
+}
+
+variable "task_cpu" {
+  description = "ECS task CPU units."
+  type        = number
+  default     = 256
+}
+
+variable "task_memory" {
+  description = "ECS task memory in MiB."
+  type        = number
+  default     = 512
+}
+
+variable "ecs_execution_role_arn" {
+  description = "Optional existing IAM role ARN for ECS task execution."
+  type        = string
+  default     = null
+}
+
+variable "ecs_task_role_arn" {
+  description = "Optional existing IAM role ARN for ECS task."
+  type        = string
+  default     = null
+}
+
+variable "enable_execute_command" {
+  description = "Enable ECS Exec on the service."
+  type        = bool
+  default     = true
+}
+
+variable "db_name" {
+  description = "Initial PostgreSQL database name."
+  type        = string
+  default     = "appdb"
+}
+
+variable "db_username" {
+  description = "PostgreSQL master username."
+  type        = string
+  default     = "dbadmin"
+}
+
+variable "db_password" {
+  description = "PostgreSQL master password."
+  type        = string
+  sensitive   = true
+  default     = "ChangeMe123!"
+}
+
+variable "db_engine_version" {
+  description = "PostgreSQL engine version."
+  type        = string
+  default     = "16.3"
+}
+
+variable "db_instance_class" {
+  description = "RDS instance class."
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "db_allocated_storage" {
+  description = "Allocated storage in GiB."
+  type        = number
+  default     = 20
+}
+
+variable "db_max_allocated_storage" {
+  description = "Maximum autoscaled storage in GiB."
+  type        = number
+  default     = 100
+}
+
+variable "db_multi_az" {
+  description = "Whether to enable Multi-AZ deployment."
+  type        = bool
+  default     = false
+}
+
+variable "db_backup_retention_period" {
+  description = "Backup retention in days."
+  type        = number
+  default     = 7
+}
+
+variable "db_deletion_protection" {
+  description = "Enable deletion protection for the DB instance."
+  type        = bool
+  default     = true
+}
+
+variable "db_skip_final_snapshot" {
+  description = "Skip final snapshot when destroying DB instance."
+  type        = bool
+  default     = false
+}
+
+variable "db_publicly_accessible" {
+  description = "Whether RDS endpoint should be publicly accessible."
+  type        = bool
+  default     = false
+}
+
+variable "common_tags" {
+  description = "Common tags applied to all resources."
+  type        = map(string)
+  default = {
+    Environment = "example"
+    ManagedBy   = "terraform"
+  }
+}

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,0 +1,20 @@
+resource "aws_instance" "this" {
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.security_group_ids
+  key_name               = var.key_name
+
+  root_block_device {
+    encrypted   = true
+    volume_size = var.root_volume_size
+    volume_type = "gp3"
+  }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  tags = merge(var.tags, { Name = var.name })
+}

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_id" {
+  description = "EC2 instance ID."
+  value       = aws_instance.this.id
+}
+
+output "private_ip" {
+  description = "Private IP of instance."
+  value       = aws_instance.this.private_ip
+}
+
+output "public_ip" {
+  description = "Public IP of instance."
+  value       = aws_instance.this.public_ip
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,0 +1,43 @@
+variable "name" {
+  description = "Name for EC2 instance."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "ami_id" {
+  description = "AMI ID for EC2 instance."
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type."
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for EC2 instance."
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "Security groups for EC2 instance."
+  type        = list(string)
+}
+
+variable "key_name" {
+  description = "Optional key pair name."
+  type        = string
+  default     = null
+}
+
+variable "root_volume_size" {
+  description = "Root volume size in GiB."
+  type        = number
+  default     = 20
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,0 +1,147 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  common_tags = merge(var.tags, { module = "ecs" })
+
+  cluster_name = coalesce(var.cluster_name, "${var.name}-cluster")
+  service_name = coalesce(var.service_name, "${var.name}-service")
+  task_family  = coalesce(var.task_family, "${var.name}-task")
+
+  task_execution_role_arn = var.execution_role_arn != null ? var.execution_role_arn : aws_iam_role.task_execution[0].arn
+  task_role_arn           = var.task_role_arn != null ? var.task_role_arn : aws_iam_role.task[0].arn
+
+  container_environment = [
+    for key, value in var.environment :
+    {
+      name  = key
+      value = value
+    }
+  ]
+
+  container_definitions = jsonencode([
+    {
+      name      = var.container_name
+      image     = var.container_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = var.container_port
+          hostPort      = var.container_port
+          protocol      = "tcp"
+        }
+      ]
+      environment = local.container_environment
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+    }
+  ])
+}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "ecs_task_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  count = var.execution_role_arn == null ? 1 : 0
+
+  name               = "${var.name}-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  tags               = merge(local.common_tags, { Name = "${var.name}-task-execution-role" })
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  count = var.execution_role_arn == null ? 1 : 0
+
+  role       = aws_iam_role.task_execution[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task" {
+  count = var.task_role_arn == null ? 1 : 0
+
+  name               = "${var.name}-task-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume_role.json
+  tags               = merge(local.common_tags, { Name = "${var.name}-task-role" })
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${var.name}"
+  retention_in_days = var.log_retention_in_days
+
+  tags = merge(local.common_tags, { Name = "/ecs/${var.name}" })
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = local.cluster_name
+
+  setting {
+    name  = "containerInsights"
+    value = var.container_insights_enabled ? "enabled" : "disabled"
+  }
+
+  tags = merge(local.common_tags, { Name = local.cluster_name })
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = local.task_family
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = tostring(var.cpu)
+  memory                   = tostring(var.memory)
+  execution_role_arn       = local.task_execution_role_arn
+  task_role_arn            = local.task_role_arn
+  container_definitions    = local.container_definitions
+
+  tags = merge(local.common_tags, { Name = local.task_family })
+
+  depends_on = [aws_iam_role_policy_attachment.task_execution]
+}
+
+resource "aws_ecs_service" "this" {
+  name                   = local.service_name
+  cluster                = aws_ecs_cluster.this.id
+  task_definition        = aws_ecs_task_definition.this.arn
+  desired_count          = var.desired_count
+  launch_type            = "FARGATE"
+  platform_version       = var.platform_version
+  enable_execute_command = var.enable_execute_command
+
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  enable_ecs_managed_tags            = true
+  propagate_tags                     = "SERVICE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = var.security_group_ids
+    assign_public_ip = var.assign_public_ip
+  }
+
+  tags = merge(local.common_tags, { Name = local.service_name })
+
+  depends_on = [aws_cloudwatch_log_group.this]
+}

--- a/modules/ecs/outputs.tf
+++ b/modules/ecs/outputs.tf
@@ -1,0 +1,24 @@
+output "cluster_id" {
+  description = "ECS cluster ID."
+  value       = aws_ecs_cluster.this.id
+}
+
+output "cluster_arn" {
+  description = "ECS cluster ARN."
+  value       = aws_ecs_cluster.this.arn
+}
+
+output "service_id" {
+  description = "ECS service ID."
+  value       = aws_ecs_service.this.id
+}
+
+output "service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.this.name
+}
+
+output "task_definition_arn" {
+  description = "Task definition ARN."
+  value       = aws_ecs_task_definition.this.arn
+}

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -1,0 +1,131 @@
+variable "name" {
+  description = "Name prefix for ECS resources."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "Name of the ECS cluster."
+  type        = string
+  default     = null
+}
+
+variable "service_name" {
+  description = "Name of the ECS service."
+  type        = string
+  default     = null
+}
+
+variable "task_family" {
+  description = "Family name for the ECS task definition."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "subnet_ids" {
+  description = "Subnets for ECS service ENIs."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security groups for ECS service ENIs."
+  type        = list(string)
+}
+
+variable "assign_public_ip" {
+  description = "Assign public IP to ECS tasks."
+  type        = bool
+  default     = false
+}
+
+variable "container_name" {
+  description = "Container name."
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image URI."
+  type        = string
+}
+
+variable "container_port" {
+  description = "Container port."
+  type        = number
+}
+
+variable "cpu" {
+  description = "Task CPU units."
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Task memory in MiB."
+  type        = number
+  default     = 512
+}
+
+variable "desired_count" {
+  description = "Desired number of ECS tasks."
+  type        = number
+  default     = 1
+}
+
+variable "execution_role_arn" {
+  description = "IAM role ARN for ECS task execution."
+  type        = string
+  default     = null
+}
+
+variable "task_role_arn" {
+  description = "IAM role ARN for ECS task."
+  type        = string
+  default     = null
+}
+
+variable "environment" {
+  description = "Environment variables for the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "container_insights_enabled" {
+  description = "Enable ECS container insights."
+  type        = bool
+  default     = true
+}
+
+variable "log_retention_in_days" {
+  description = "CloudWatch log retention period."
+  type        = number
+  default     = 30
+}
+
+variable "platform_version" {
+  description = "Fargate platform version."
+  type        = string
+  default     = "LATEST"
+}
+
+variable "enable_execute_command" {
+  description = "Enable ECS Exec for tasks."
+  type        = bool
+  default     = false
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Lower bound on healthy tasks during deployment."
+  type        = number
+  default     = 50
+}
+
+variable "deployment_maximum_percent" {
+  description = "Upper bound on running tasks during deployment."
+  type        = number
+  default     = 200
+}

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,39 @@
+locals {
+  identifier = coalesce(var.identifier, var.name)
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "${local.identifier}-subnet-group"
+  subnet_ids = var.subnet_ids
+  tags       = merge(var.tags, { Name = "${local.identifier}-subnet-group" })
+}
+
+resource "aws_db_instance" "this" {
+  identifier                   = local.identifier
+  engine                       = "postgres"
+  engine_version               = var.engine_version
+  instance_class               = var.instance_class
+  allocated_storage            = var.allocated_storage
+  max_allocated_storage        = var.max_allocated_storage
+  storage_type                 = "gp3"
+  storage_encrypted            = true
+  db_name                      = var.db_name
+  username                     = var.username
+  password                     = var.password
+  port                         = var.port
+  db_subnet_group_name         = aws_db_subnet_group.this.name
+  vpc_security_group_ids       = var.security_group_ids
+  backup_retention_period      = var.backup_retention_period
+  backup_window                = var.backup_window
+  maintenance_window           = var.maintenance_window
+  multi_az                     = var.multi_az
+  publicly_accessible          = var.publicly_accessible
+  skip_final_snapshot          = var.skip_final_snapshot
+  final_snapshot_identifier    = var.skip_final_snapshot ? null : coalesce(var.final_snapshot_identifier, "${local.identifier}-final-snapshot")
+  delete_automated_backups     = true
+  auto_minor_version_upgrade   = true
+  deletion_protection          = var.deletion_protection
+  performance_insights_enabled = var.performance_insights_enabled
+  apply_immediately            = var.apply_immediately
+  tags                         = merge(var.tags, { Name = local.identifier })
+}

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,44 @@
+output "db_instance_id" {
+  description = "RDS instance ID."
+  value       = aws_db_instance.this.id
+}
+
+output "db_instance_arn" {
+  description = "RDS instance ARN."
+  value       = aws_db_instance.this.arn
+}
+
+output "db_address" {
+  description = "RDS endpoint address."
+  value       = aws_db_instance.this.address
+}
+
+output "db_name" {
+  description = "Database name."
+  value       = aws_db_instance.this.db_name
+}
+
+output "db_username" {
+  description = "Master username."
+  value       = aws_db_instance.this.username
+}
+
+output "db_port" {
+  description = "RDS endpoint port."
+  value       = aws_db_instance.this.port
+}
+
+output "db_subnet_group_name" {
+  description = "DB subnet group name."
+  value       = aws_db_subnet_group.this.name
+}
+
+output "db_instance_endpoint" {
+  description = "RDS endpoint in host:port form."
+  value       = aws_db_instance.this.endpoint
+}
+
+output "db_instance_port" {
+  description = "RDS endpoint port."
+  value       = aws_db_instance.this.port
+}

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,132 @@
+variable "name" {
+  description = "RDS instance identifier prefix."
+  type        = string
+}
+
+variable "identifier" {
+  description = "Explicit DB instance identifier. If null, name is used."
+  type        = string
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "subnet_ids" {
+  description = "Private subnet IDs for DB subnet group."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs for RDS."
+  type        = list(string)
+}
+
+variable "db_name" {
+  description = "Initial database name."
+  type        = string
+}
+
+variable "username" {
+  description = "Master username."
+  type        = string
+}
+
+variable "password" {
+  description = "Master password."
+  type        = string
+  sensitive   = true
+}
+
+variable "port" {
+  description = "Database port."
+  type        = number
+  default     = 5432
+}
+
+variable "instance_class" {
+  description = "RDS instance class."
+  type        = string
+  default     = "db.t4g.micro"
+}
+
+variable "allocated_storage" {
+  description = "Allocated storage in GiB."
+  type        = number
+  default     = 20
+}
+
+variable "max_allocated_storage" {
+  description = "Maximum autoscaled storage in GiB."
+  type        = number
+  default     = 100
+}
+
+variable "engine_version" {
+  description = "PostgreSQL engine version."
+  type        = string
+  default     = "16.3"
+}
+
+variable "backup_retention_period" {
+  description = "Backup retention in days."
+  type        = number
+  default     = 7
+}
+
+variable "backup_window" {
+  description = "Daily backup window (UTC)."
+  type        = string
+  default     = "03:00-04:00"
+}
+
+variable "maintenance_window" {
+  description = "Weekly maintenance window (UTC)."
+  type        = string
+  default     = "sun:04:00-sun:05:00"
+}
+
+variable "multi_az" {
+  description = "Enable Multi-AZ deployment."
+  type        = bool
+  default     = false
+}
+
+variable "deletion_protection" {
+  description = "Enable deletion protection."
+  type        = bool
+  default     = true
+}
+
+variable "performance_insights_enabled" {
+  description = "Enable Performance Insights."
+  type        = bool
+  default     = true
+}
+
+variable "skip_final_snapshot" {
+  description = "Skip final snapshot on deletion."
+  type        = bool
+  default     = false
+}
+
+variable "final_snapshot_identifier" {
+  description = "Identifier used for the final snapshot when skip_final_snapshot is false."
+  type        = string
+  default     = null
+}
+
+variable "publicly_accessible" {
+  description = "Whether the database endpoint is publicly accessible."
+  type        = bool
+  default     = false
+}
+
+variable "apply_immediately" {
+  description = "Apply changes immediately."
+  type        = bool
+  default     = false
+}

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,131 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  common_tags = merge(var.tags, { module = "vpc" })
+  nat_count   = var.enable_nat_gateway ? (var.single_nat_gateway ? 1 : length(var.public_subnet_cidrs)) : 0
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = merge(local.common_tags, { Name = "${var.name}-vpc" })
+
+  lifecycle {
+    precondition {
+      condition     = length(var.public_subnet_cidrs) == length(var.azs)
+      error_message = "public_subnet_cidrs length must match azs length."
+    }
+
+    precondition {
+      condition     = length(var.private_subnet_cidrs) == length(var.azs)
+      error_message = "private_subnet_cidrs length must match azs length."
+    }
+
+    precondition {
+      condition     = !var.enable_nat_gateway || var.single_nat_gateway || length(var.public_subnet_cidrs) == length(var.private_subnet_cidrs)
+      error_message = "When single_nat_gateway is false, public and private subnet counts must match."
+    }
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, { Name = "${var.name}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  vpc_id                  = aws_vpc.this.id
+  availability_zone       = var.azs[count.index]
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  map_public_ip_on_launch = var.map_public_ip_on_launch
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}-public-${var.azs[count.index]}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id            = aws_vpc.this.id
+  availability_zone = var.azs[count.index]
+  cidr_block        = var.private_subnet_cidrs[count.index]
+
+  tags = merge(local.common_tags, {
+    Name = "${var.name}-private-${var.azs[count.index]}"
+    Tier = "private"
+  })
+}
+
+resource "aws_eip" "nat" {
+  count = local.nat_count
+
+  domain = "vpc"
+  tags   = merge(local.common_tags, { Name = "${var.name}-nat-eip-${count.index + 1}" })
+}
+
+resource "aws_nat_gateway" "this" {
+  count = local.nat_count
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[var.single_nat_gateway ? 0 : count.index].id
+
+  tags = merge(local.common_tags, { Name = "${var.name}-nat-${count.index + 1}" })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(local.common_tags, { Name = "${var.name}-public-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  count = length(var.public_subnet_cidrs)
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  vpc_id = aws_vpc.this.id
+  tags   = merge(local.common_tags, { Name = "${var.name}-private-rt-${count.index + 1}" })
+}
+
+resource "aws_route" "private_nat" {
+  count = var.enable_nat_gateway ? length(var.private_subnet_cidrs) : 0
+
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[var.single_nat_gateway ? 0 : count.index].id
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(var.private_subnet_cidrs)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_arn" {
+  description = "ARN of the VPC."
+  value       = aws_vpc.this.arn
+}
+
+output "public_subnet_ids" {
+  description = "IDs of public subnets."
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of private subnets."
+  value       = aws_subnet.private[*].id
+}
+
+output "nat_gateway_ids" {
+  description = "IDs of NAT gateways."
+  value       = aws_nat_gateway.this[*].id
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table."
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_ids" {
+  description = "IDs of private route tables."
+  value       = aws_route_table.private[*].id
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,64 @@
+variable "name" {
+  description = "Name prefix applied to VPC resources."
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "azs" {
+  description = "Availability zones used for public and private subnets."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.azs) > 0
+    error_message = "At least one availability zone is required."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for public subnets. Length must match azs."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) > 0
+    error_message = "At least one public subnet CIDR is required."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for private subnets. Length must match azs."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_cidrs) > 0
+    error_message = "At least one private subnet CIDR is required."
+  }
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Assign public IPs to instances launched into public subnets."
+  type        = bool
+  default     = true
+}
+
+variable "enable_nat_gateway" {
+  description = "Create NAT gateway resources for private subnet egress."
+  type        = bool
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "Create a single shared NAT gateway when enabled."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags applied to all resources in this module."
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add reusable Terraform modules under `modules/` for `vpc`, `ecs`, `rds`, and `ec2`
- implement production-style VPC networking with public/private subnets, internet gateway, NAT gateway, and route tables
- implement ECS Fargate cluster, task definition, and service module with optional IAM role creation and CloudWatch logging
- implement RDS PostgreSQL module with subnet group, encryption, backups, and deletion safety controls
- add a root example in `examples/` wiring VPC + ECS + RDS together with security groups and outputs
- pin provider selections in `examples/.terraform.lock.hcl` for reproducible initialization

## Testing
- `/tmp/terraform fmt -recursive`
- `/tmp/terraform init -backend=false` (run in `examples/`)
- `/tmp/terraform validate` (run in `examples/`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92efc6d1-c6f9-4002-b250-faf6d9264e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92efc6d1-c6f9-4002-b250-faf6d9264e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

