### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+**BugBot** is a Node.js security scanner that statically analyzes Terraform and Kubernetes IaC files for common misconfigurations.
+
+### Running the application
+
+```bash
+node bot/bugbot.js
+```
+
+This reads `terraform/main.tf` and `k8s/deployment.yaml`, writes results to `report/findings.json`, and optionally posts to Slack if `SLACK_WEBHOOK` env var is set. The script must be run from the repository root (it uses relative paths).
+
+### Key notes
+
+- **No build step required** — the project is plain CommonJS JavaScript.
+- **No test suite** — `npm test` is a placeholder that exits with code 1. There are no lint or type-check scripts configured.
+- **Single dependency** — `axios` (used for optional Slack webhook posting).
+- **No database or external services needed** — the scanner only reads local files.
+- **CI uses Node 18** (see `.github/workflows/bugbot.yml`), but any Node.js >= 18 works.
+- **`report/findings.json`** is regenerated on each run; changes to it should not be committed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the BugBot proof-of-concept security scanner.

## What was done

- **Dependencies installed**: `npm install` (single dependency: `axios`)
- **Application verified**: Ran `node bot/bugbot.js` — scanner successfully detected both intentional vulnerabilities in the sample IaC files
- **Update script configured**: `npm install` (runs on VM startup to keep dependencies fresh)

## Evidence of working environment

Scanner output showing both findings detected:

[bugbot_scan_output.log](https://cursor.com/agents/bc-058e6b3d-f132-4afe-b19a-6a2bae480659/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbugbot_scan_output.log)

## Changes

- `AGENTS.md` — New file with Cursor Cloud-specific instructions covering how to run the scanner, key caveats (no build step, no test suite, relative paths requirement, etc.)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-058e6b3d-f132-4afe-b19a-6a2bae480659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-058e6b3d-f132-4afe-b19a-6a2bae480659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

