### PR TITLE
Add reusable AWS EC2 Terraform module library

### DIFF
--- a/modules/ec2/README.md
+++ b/modules/ec2/README.md
@@ -1,0 +1,89 @@
+# EC2 Terraform Module
+
+Terraform module to provision:
+- An EC2 instance
+- A security group (optional, with configurable ingress/egress rules)
+- A key pair (optional)
+
+## Requirements
+
+- Terraform `>= 1.5.0`
+- AWS provider `>= 5.0, < 6.0`
+
+## Usage
+
+```hcl
+module "ec2" {
+  source = "./modules/ec2"
+
+  ami_id        = "ami-0123456789abcdef0"
+  instance_name = "app-server"
+  subnet_id     = "subnet-0123456789abcdef0"
+
+  create_security_group = true
+  vpc_id                = "vpc-0123456789abcdef0"
+  security_group_ingress_rules = [
+    {
+      description = "Allow SSH"
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["203.0.113.0/24"]
+    }
+  ]
+
+  create_key_pair = true
+  key_name        = "app-server-key"
+  public_key      = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ..."
+
+  tags = {
+    Environment = "dev"
+    Project     = "infra"
+  }
+}
+```
+
+## Notes
+
+- When `create_security_group = true`, `vpc_id` is required.
+- When `create_key_pair = true`, both `key_name` and `public_key` are required.
+- If `create_security_group = false`, pass existing security groups in `security_group_ids`.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|---|---|---|---|---|
+| ami_id | AMI ID to use for the EC2 instance. | `string` | n/a | yes |
+| instance_type | EC2 instance type. | `string` | `"t3.micro"` | no |
+| instance_name | Name tag value for the EC2 instance. | `string` | `"ec2-instance"` | no |
+| subnet_id | Subnet ID in which to launch the instance. | `string` | `null` | no |
+| availability_zone | Availability zone for the instance. | `string` | `null` | no |
+| associate_public_ip_address | Whether to associate a public IP. | `bool` | `null` | no |
+| user_data | User data script. | `string` | `null` | no |
+| create_key_pair | Whether to create key pair. | `bool` | `false` | no |
+| key_name | Key pair name. | `string` | `null` | no |
+| public_key | Public key material. | `string` | `null` | no |
+| create_security_group | Whether to create security group. | `bool` | `true` | no |
+| security_group_name | Name for created security group. | `string` | `"ec2-instance-sg"` | no |
+| security_group_description | Description for created security group. | `string` | `"Security group managed by Terraform module ec2"` | no |
+| vpc_id | VPC ID for created security group. | `string` | `null` | no |
+| security_group_ids | Existing security group IDs to attach. | `list(string)` | `[]` | no |
+| security_group_ingress_rules | Ingress rules for created security group. | `list(object)` | `[]` | no |
+| security_group_egress_rules | Egress rules for created security group. | `list(object)` | allow-all rule | no |
+| tags | Tags applied to all resources. | `map(string)` | `{}` | no |
+| instance_tags | Additional instance-only tags. | `map(string)` | `{}` | no |
+| security_group_tags | Additional security-group-only tags. | `map(string)` | `{}` | no |
+| key_pair_tags | Additional key-pair-only tags. | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| instance_id | ID of the EC2 instance. |
+| instance_arn | ARN of the EC2 instance. |
+| instance_private_ip | Private IP of the EC2 instance. |
+| instance_public_ip | Public IP of the EC2 instance. |
+| security_group_id | Created security group ID, if enabled. |
+| security_group_ids | All security groups attached to instance. |
+| key_pair_name | Key pair name attached to instance. |
+| key_pair_id | Created key pair ID, if enabled. |

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,0 +1,71 @@
+locals {
+  effective_security_group_ids = var.create_security_group ? concat(var.security_group_ids, [aws_security_group.this[0].id]) : var.security_group_ids
+  instance_key_name            = var.create_key_pair ? aws_key_pair.this[0].key_name : var.key_name
+
+  merged_instance_tags       = merge(var.tags, var.instance_tags, { Name = var.instance_name })
+  merged_key_pair_tags       = merge(var.tags, var.key_pair_tags, { Name = coalesce(var.key_name, var.instance_name) })
+  merged_security_group_tags = merge(var.tags, var.security_group_tags, { Name = var.security_group_name })
+}
+
+resource "aws_security_group" "this" {
+  count = var.create_security_group ? 1 : 0
+
+  name        = var.security_group_name
+  description = var.security_group_description
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.security_group_ingress_rules
+    content {
+      description      = ingress.value.description
+      from_port        = ingress.value.from_port
+      to_port          = ingress.value.to_port
+      protocol         = ingress.value.protocol
+      cidr_blocks      = ingress.value.cidr_blocks
+      ipv6_cidr_blocks = ingress.value.ipv6_cidr_blocks
+      prefix_list_ids  = ingress.value.prefix_list_ids
+      security_groups  = ingress.value.security_groups
+      self             = ingress.value.self
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.security_group_egress_rules
+    content {
+      description      = egress.value.description
+      from_port        = egress.value.from_port
+      to_port          = egress.value.to_port
+      protocol         = egress.value.protocol
+      cidr_blocks      = egress.value.cidr_blocks
+      ipv6_cidr_blocks = egress.value.ipv6_cidr_blocks
+      prefix_list_ids  = egress.value.prefix_list_ids
+      security_groups  = egress.value.security_groups
+      self             = egress.value.self
+    }
+  }
+
+  tags = local.merged_security_group_tags
+}
+
+resource "aws_key_pair" "this" {
+  count = var.create_key_pair ? 1 : 0
+
+  key_name   = var.key_name
+  public_key = var.public_key
+
+  tags = local.merged_key_pair_tags
+}
+
+resource "aws_instance" "this" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+
+  subnet_id                   = var.subnet_id
+  availability_zone           = var.availability_zone
+  associate_public_ip_address = var.associate_public_ip_address
+  vpc_security_group_ids      = length(local.effective_security_group_ids) > 0 ? local.effective_security_group_ids : null
+  key_name                    = local.instance_key_name
+  user_data                   = var.user_data
+
+  tags = local.merged_instance_tags
+}

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,0 +1,39 @@
+output "instance_id" {
+  description = "ID of the EC2 instance."
+  value       = aws_instance.this.id
+}
+
+output "instance_arn" {
+  description = "ARN of the EC2 instance."
+  value       = aws_instance.this.arn
+}
+
+output "instance_private_ip" {
+  description = "Private IP address of the EC2 instance."
+  value       = aws_instance.this.private_ip
+}
+
+output "instance_public_ip" {
+  description = "Public IP address of the EC2 instance, if assigned."
+  value       = aws_instance.this.public_ip
+}
+
+output "security_group_id" {
+  description = "ID of the security group created by this module, if enabled."
+  value       = try(aws_security_group.this[0].id, null)
+}
+
+output "security_group_ids" {
+  description = "All security group IDs attached to the instance."
+  value       = local.effective_security_group_ids
+}
+
+output "key_pair_name" {
+  description = "Key pair name attached to the instance."
+  value       = local.instance_key_name
+}
+
+output "key_pair_id" {
+  description = "ID of the key pair created by this module, if enabled."
+  value       = try(aws_key_pair.this[0].id, null)
+}

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,0 +1,181 @@
+variable "ami_id" {
+  description = "AMI ID to use for the EC2 instance."
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type."
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "instance_name" {
+  description = "Name tag value for the EC2 instance."
+  type        = string
+  default     = "ec2-instance"
+}
+
+variable "subnet_id" {
+  description = "Subnet ID in which to launch the instance."
+  type        = string
+  default     = null
+}
+
+variable "availability_zone" {
+  description = "Availability zone for the instance. Keep null to let AWS choose."
+  type        = string
+  default     = null
+}
+
+variable "associate_public_ip_address" {
+  description = "Whether to associate a public IP address to the instance."
+  type        = bool
+  default     = null
+}
+
+variable "user_data" {
+  description = "User data script passed to the instance."
+  type        = string
+  default     = null
+}
+
+variable "create_key_pair" {
+  description = "Whether to create an AWS key pair in this module."
+  type        = bool
+  default     = false
+}
+
+variable "key_name" {
+  description = "Key pair name for the instance. Required when create_key_pair is true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.create_key_pair || (var.key_name != null && trim(var.key_name) != "")
+    error_message = "key_name must be provided when create_key_pair is true."
+  }
+}
+
+variable "public_key" {
+  description = "Public key material for key pair creation. Required when create_key_pair is true."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.create_key_pair || (var.public_key != null && trim(var.public_key) != "")
+    error_message = "public_key must be provided when create_key_pair is true."
+  }
+
+  validation {
+    condition     = var.create_key_pair || var.public_key == null
+    error_message = "public_key can only be set when create_key_pair is true."
+  }
+}
+
+variable "create_security_group" {
+  description = "Whether to create a dedicated security group in this module."
+  type        = bool
+  default     = true
+}
+
+variable "security_group_name" {
+  description = "Name of the security group created by this module."
+  type        = string
+  default     = "ec2-instance-sg"
+}
+
+variable "security_group_description" {
+  description = "Description of the security group created by this module."
+  type        = string
+  default     = "Security group managed by Terraform module ec2"
+}
+
+variable "vpc_id" {
+  description = "VPC ID where the managed security group is created."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = !var.create_security_group || (var.vpc_id != null && trim(var.vpc_id) != "")
+    error_message = "vpc_id must be provided when create_security_group is true."
+  }
+}
+
+variable "security_group_ids" {
+  description = "Existing security group IDs to attach to the instance."
+  type        = list(string)
+  default     = []
+}
+
+variable "security_group_ingress_rules" {
+  description = "Ingress rules applied to the created security group."
+  type = list(object({
+    description      = optional(string, null)
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = optional(list(string), [])
+    ipv6_cidr_blocks = optional(list(string), [])
+    prefix_list_ids  = optional(list(string), [])
+    security_groups  = optional(list(string), [])
+    self             = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition     = var.create_security_group || length(var.security_group_ingress_rules) == 0
+    error_message = "security_group_ingress_rules can only be set when create_security_group is true."
+  }
+}
+
+variable "security_group_egress_rules" {
+  description = "Egress rules applied to the created security group."
+  type = list(object({
+    description      = optional(string, null)
+    from_port        = number
+    to_port          = number
+    protocol         = string
+    cidr_blocks      = optional(list(string), [])
+    ipv6_cidr_blocks = optional(list(string), [])
+    prefix_list_ids  = optional(list(string), [])
+    security_groups  = optional(list(string), [])
+    self             = optional(bool, false)
+  }))
+  default = [
+    {
+      description      = "Allow all outbound traffic"
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
+    }
+  ]
+}
+
+variable "tags" {
+  description = "Tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "instance_tags" {
+  description = "Additional tags applied only to the EC2 instance."
+  type        = map(string)
+  default     = {}
+}
+
+variable "security_group_tags" {
+  description = "Additional tags applied only to the security group."
+  type        = map(string)
+  default     = {}
+}
+
+variable "key_pair_tags" {
+  description = "Additional tags applied only to the key pair."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/ec2/versions.tf
+++ b/modules/ec2/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add new `modules/ec2` Terraform module for EC2 instances, optional security group management, and optional key pair management
- include `variables.tf`, `outputs.tf`, and `versions.tf` with input validation and provider constraints
- add module-level `README.md` with usage, inputs, outputs, and behavior notes

## Validation plan
- run `terraform fmt` for module formatting
- run `terraform init -backend=false` and `terraform validate` in `modules/ec2`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6883a68d-b711-4a2e-a527-4532fee51953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6883a68d-b711-4a2e-a527-4532fee51953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new EC2 module for provisioning instances with optional security group and key pair creation, supporting configurable ingress/egress rules, flexible tagging across resources, and conditional feature flags for customized deployments.

* **Documentation**
  * Added comprehensive module documentation with usage examples, input and output specifications, version requirements, and configuration guidance for conditional features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->