### PR TITLE
Add reusable AWS VPC module and web-server security group

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -31,7 +31,7 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.this.id
   cidr_block              = var.public_subnet_cidrs[count.index]
   availability_zone       = var.availability_zones[count.index]
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = var.map_public_ip_on_launch
 
   tags = merge(var.tags, {
     Name = "${var.name}-public-${var.availability_zones[count.index]}"
@@ -131,4 +131,68 @@ resource "aws_route_table_association" "private" {
 
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
+}
+
+# ---------------------------------------------------------------
+# VPC Flow Logs
+# ---------------------------------------------------------------
+resource "aws_flow_log" "this" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  vpc_id                   = aws_vpc.this.id
+  traffic_type             = "ALL"
+  iam_role_arn             = aws_iam_role.flow_log[0].arn
+  log_destination          = aws_cloudwatch_log_group.flow_log[0].arn
+  log_destination_type     = "cloud-watch-logs"
+  max_aggregation_interval = 60
+
+  tags = merge(var.tags, { Name = "${var.name}-flow-log" })
+}
+
+resource "aws_cloudwatch_log_group" "flow_log" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name              = "/aws/vpc-flow-log/${var.name}"
+  retention_in_days = var.flow_log_retention_days
+
+  tags = merge(var.tags, { Name = "${var.name}-flow-log-group" })
+}
+
+resource "aws_iam_role" "flow_log" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.name}-vpc-flow-log-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name}-vpc-flow-log-role" })
+}
+
+resource "aws_iam_role_policy" "flow_log" {
+  count = var.enable_flow_logs ? 1 : 0
+
+  name = "${var.name}-vpc-flow-log-policy"
+  role = aws_iam_role.flow_log[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ]
+      Resource = "*"
+    }]
+  })
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,0 +1,134 @@
+locals {
+  nat_count = var.single_nat_gateway ? 1 : 2
+}
+
+# ---------------------------------------------------------------
+# VPC
+# ---------------------------------------------------------------
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = var.enable_dns_support
+  enable_dns_hostnames = var.enable_dns_hostnames
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+# ---------------------------------------------------------------
+# Internet Gateway
+# ---------------------------------------------------------------
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-igw" })
+}
+
+# ---------------------------------------------------------------
+# Public Subnets
+# ---------------------------------------------------------------
+resource "aws_subnet" "public" {
+  count = 2
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-public-${var.availability_zones[count.index]}"
+    Tier = "public"
+  })
+}
+
+# ---------------------------------------------------------------
+# Private Subnets
+# ---------------------------------------------------------------
+resource "aws_subnet" "private" {
+  count = 2
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-${var.availability_zones[count.index]}"
+    Tier = "private"
+  })
+}
+
+# ---------------------------------------------------------------
+# Elastic IP(s) for NAT Gateway(s)
+# ---------------------------------------------------------------
+resource "aws_eip" "nat" {
+  count  = local.nat_count
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nat-eip-${count.index}"
+  })
+}
+
+# ---------------------------------------------------------------
+# NAT Gateway(s) — placed in public subnets
+# ---------------------------------------------------------------
+resource "aws_nat_gateway" "this" {
+  count = local.nat_count
+
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nat-${count.index}"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# ---------------------------------------------------------------
+# Public Route Table
+# ---------------------------------------------------------------
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-public-rt" })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  count = 2
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# ---------------------------------------------------------------
+# Private Route Table(s)
+# ---------------------------------------------------------------
+resource "aws_route_table" "private" {
+  count = local.nat_count
+
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-private-rt-${count.index}"
+  })
+}
+
+resource "aws_route" "private_nat" {
+  count = local.nat_count
+
+  route_table_id         = aws_route_table.private[count.index].id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this[count.index].id
+}
+
+resource "aws_route_table_association" "private" {
+  count = 2
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[var.single_nat_gateway ? 0 : count.index].id
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,0 +1,39 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC."
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets."
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets."
+  value       = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  description = "ID of the Internet Gateway."
+  value       = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_ids" {
+  description = "IDs of the NAT Gateway(s)."
+  value       = aws_nat_gateway.this[*].id
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table."
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_ids" {
+  description = "IDs of the private route table(s)."
+  value       = aws_route_table.private[*].id
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -37,3 +37,13 @@ output "private_route_table_ids" {
   description = "IDs of the private route table(s)."
   value       = aws_route_table.private[*].id
 }
+
+output "flow_log_id" {
+  description = "ID of the VPC Flow Log, if enabled."
+  value       = try(aws_flow_log.this[0].id, null)
+}
+
+output "flow_log_group_arn" {
+  description = "ARN of the CloudWatch Log Group for VPC Flow Logs, if enabled."
+  value       = try(aws_cloudwatch_log_group.flow_log[0].arn, null)
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -1,0 +1,71 @@
+variable "name" {
+  description = "Name prefix for all resources."
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.cidr_block, 0))
+    error_message = "cidr_block must be a valid IPv4 CIDR."
+  }
+}
+
+variable "availability_zones" {
+  description = "List of two availability zones."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.availability_zones) == 2
+    error_message = "Exactly two availability zones must be provided."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for the two public subnets (one per AZ)."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == 2
+    error_message = "Exactly two public subnet CIDRs must be provided."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for the two private subnets (one per AZ)."
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+
+  validation {
+    condition     = length(var.private_subnet_cidrs) == 2
+    error_message = "Exactly two private subnet CIDRs must be provided."
+  }
+}
+
+variable "enable_dns_support" {
+  description = "Whether to enable DNS support in the VPC."
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_hostnames" {
+  description = "Whether to enable DNS hostnames in the VPC."
+  type        = bool
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT Gateway instead of one per AZ (cost optimisation)."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags applied to every resource."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -33,6 +33,11 @@ variable "public_subnet_cidrs" {
     condition     = length(var.public_subnet_cidrs) == 2
     error_message = "Exactly two public subnet CIDRs must be provided."
   }
+
+  validation {
+    condition     = alltrue([for cidr in var.public_subnet_cidrs : can(cidrhost(cidr, 0))])
+    error_message = "All public_subnet_cidrs must be valid IPv4 CIDRs."
+  }
 }
 
 variable "private_subnet_cidrs" {
@@ -43,6 +48,11 @@ variable "private_subnet_cidrs" {
   validation {
     condition     = length(var.private_subnet_cidrs) == 2
     error_message = "Exactly two private subnet CIDRs must be provided."
+  }
+
+  validation {
+    condition     = alltrue([for cidr in var.private_subnet_cidrs : can(cidrhost(cidr, 0))])
+    error_message = "All private_subnet_cidrs must be valid IPv4 CIDRs."
   }
 }
 
@@ -62,6 +72,29 @@ variable "single_nat_gateway" {
   description = "Use a single NAT Gateway instead of one per AZ (cost optimisation)."
   type        = bool
   default     = true
+}
+
+variable "enable_flow_logs" {
+  description = "Whether to enable VPC Flow Logs for network monitoring."
+  type        = bool
+  default     = true
+}
+
+variable "flow_log_retention_days" {
+  description = "Number of days to retain VPC Flow Logs in CloudWatch."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.flow_log_retention_days)
+    error_message = "flow_log_retention_days must be a valid CloudWatch Logs retention value."
+  }
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Whether public subnets auto-assign public IPs. Set to false to control public IPs via EIP or ALB instead."
+  type        = bool
+  default     = false
 }
 
 variable "tags" {

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,32 +43,49 @@ resource "aws_security_group" "web" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "http" {
+  for_each = toset(var.web_ingress_cidr_ipv4)
+
   security_group_id = aws_security_group.web.id
-  description       = "Allow HTTP"
+  description       = "Allow HTTP from ${each.value}"
   from_port         = 80
   to_port           = 80
   ip_protocol       = "tcp"
-  cidr_ipv4         = "0.0.0.0/0"
+  cidr_ipv4         = each.value
 
   tags = merge(var.tags, { Name = "${var.project_name}-http-ingress" })
 }
 
 resource "aws_vpc_security_group_ingress_rule" "https" {
+  for_each = toset(var.web_ingress_cidr_ipv4)
+
   security_group_id = aws_security_group.web.id
-  description       = "Allow HTTPS"
+  description       = "Allow HTTPS from ${each.value}"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+
+  tags = merge(var.tags, { Name = "${var.project_name}-https-ingress" })
+}
+
+resource "aws_vpc_security_group_egress_rule" "https_out" {
+  security_group_id = aws_security_group.web.id
+  description       = "Allow outbound HTTPS (API calls, package updates)"
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"
   cidr_ipv4         = "0.0.0.0/0"
 
-  tags = merge(var.tags, { Name = "${var.project_name}-https-ingress" })
+  tags = merge(var.tags, { Name = "${var.project_name}-https-egress" })
 }
 
-resource "aws_vpc_security_group_egress_rule" "all_outbound" {
+resource "aws_vpc_security_group_egress_rule" "http_out" {
   security_group_id = aws_security_group.web.id
-  description       = "Allow all outbound traffic"
-  ip_protocol       = "-1"
+  description       = "Allow outbound HTTP (package mirrors, redirects)"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
   cidr_ipv4         = "0.0.0.0/0"
 
-  tags = merge(var.tags, { Name = "${var.project_name}-all-egress" })
+  tags = merge(var.tags, { Name = "${var.project_name}-http-egress" })
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,74 @@
-resource "aws_security_group" "bad_sg" {
-  name = "bad_sg"
+terraform {
+  required_version = ">= 1.5.0"
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]  # ❌ insecure
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
   }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# ---------------------------------------------------------------
+# VPC
+# ---------------------------------------------------------------
+module "vpc" {
+  source = "../modules/vpc"
+
+  name               = var.project_name
+  cidr_block         = var.vpc_cidr_block
+  availability_zones = var.availability_zones
+
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+
+  single_nat_gateway = var.single_nat_gateway
+
+  tags = var.tags
+}
+
+# ---------------------------------------------------------------
+# Web Server Security Group
+# ---------------------------------------------------------------
+resource "aws_security_group" "web" {
+  name        = "${var.project_name}-web-sg"
+  description = "Allow inbound HTTP and HTTPS traffic"
+  vpc_id      = module.vpc.vpc_id
+
+  tags = merge(var.tags, { Name = "${var.project_name}-web-sg" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  security_group_id = aws_security_group.web.id
+  description       = "Allow HTTP"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = merge(var.tags, { Name = "${var.project_name}-http-ingress" })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "https" {
+  security_group_id = aws_security_group.web.id
+  description       = "Allow HTTPS"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = merge(var.tags, { Name = "${var.project_name}-https-ingress" })
+}
+
+resource "aws_vpc_security_group_egress_rule" "all_outbound" {
+  security_group_id = aws_security_group.web.id
+  description       = "Allow all outbound traffic"
+  ip_protocol       = "-1"
+  cidr_ipv4         = "0.0.0.0/0"
+
+  tags = merge(var.tags, { Name = "${var.project_name}-all-egress" })
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = module.vpc.vpc_id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC."
+  value       = module.vpc.vpc_cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets."
+  value       = module.vpc.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets."
+  value       = module.vpc.private_subnet_ids
+}
+
+output "internet_gateway_id" {
+  description = "ID of the Internet Gateway."
+  value       = module.vpc.internet_gateway_id
+}
+
+output "nat_gateway_ids" {
+  description = "IDs of the NAT Gateway(s)."
+  value       = module.vpc.nat_gateway_ids
+}
+
+output "web_security_group_id" {
+  description = "ID of the web server security group."
+  value       = aws_security_group.web.id
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,6 +40,17 @@ variable "single_nat_gateway" {
   default     = true
 }
 
+variable "web_ingress_cidr_ipv4" {
+  description = "IPv4 CIDR blocks allowed to reach the web security group. Restrict to known ranges in production."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+
+  validation {
+    condition     = alltrue([for cidr in var.web_ingress_cidr_ipv4 : can(cidrhost(cidr, 0))])
+    error_message = "All entries in web_ingress_cidr_ipv4 must be valid IPv4 CIDRs."
+  }
+}
+
 variable "tags" {
   description = "Tags applied to every resource."
   type        = map(string)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,49 @@
+variable "aws_region" {
+  description = "AWS region to deploy into."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Project name used as a prefix for resource names."
+  type        = string
+  default     = "my-project"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of two availability zones."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1b"]
+}
+
+variable "public_subnet_cidrs" {
+  description = "CIDR blocks for the two public subnets."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for the two private subnets."
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
+variable "single_nat_gateway" {
+  description = "Use a single NAT Gateway instead of one per AZ."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Tags applied to every resource."
+  type        = map(string)
+  default = {
+    ManagedBy = "terraform"
+  }
+}


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a reusable Terraform VPC module (`modules/vpc/`) and updates the root `terraform/` configuration to provision a production-ready AWS networking layer with a web-server security group. Includes security hardening based on an OWASP-aligned code review.

### What's included

**`modules/vpc/`** — reusable VPC module:
- VPC with configurable CIDR block, DNS support, and DNS hostnames
- 2 public subnets (one per AZ) — `map_public_ip_on_launch` defaults to `false`
- 2 private subnets (one per AZ)
- Internet Gateway and NAT Gateway(s) with Elastic IPs (single or per-AZ mode)
- Route tables and associations for public and private subnets
- VPC Flow Logs to CloudWatch with dedicated IAM role (enabled by default)
- Input validation on CIDRs, AZ count, and subnet count
- Full variables, outputs, and tagging support

**`terraform/`** — root configuration:
- Consumes the VPC module with sensible defaults
- Web-server security group allowing inbound HTTP/HTTPS with **configurable source CIDRs**
- Egress restricted to HTTP/HTTPS only (least-privilege)
- Uses modern `aws_vpc_security_group_ingress_rule` / `egress_rule` resources

### Security Review Findings & Fixes

| # | OWASP | Severity | Finding | Status |
|---|-------|----------|---------|--------|
| V1 | A09 | **High** | No VPC Flow Logs — no network audit trail | ✅ Fixed |
| V2 | A05 | **Medium** | HTTP ingress open to `0.0.0.0/0` with no way to restrict | ✅ Fixed |
| V3 | A05 | **Medium** | Egress allows all protocols/ports (`-1` / `0.0.0.0/0`) | ✅ Fixed |
| V4 | A05 | **Low** | Subnet CIDRs not validated for format | ✅ Fixed |
| V5 | A05 | **Medium** | `map_public_ip_on_launch = true` auto-assigns public IPs | ✅ Fixed |
| V6 | A01 | **Low** | No explicit NACL hardening | Deferred (AWS default NACL is allow-all; custom NACLs are environment-specific) |
| V7 | A02 | **Info** | No backend/state encryption configured | By design (root config concern, not module) |

### Testing

- `terraform fmt -check` — passed (both module and root)
- `terraform validate` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96cfa84c-6991-4cce-bb45-79aa7a4309de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96cfa84c-6991-4cce-bb45-79aa7a4309de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


___

## **CodeAnt-AI Description**
**Set up a reusable AWS network stack with safer web access rules**

### What Changed
- Replaced the old standalone security group with a full VPC setup that creates public and private subnets, internet access for public traffic, NAT-based outbound access for private subnets, and exported network IDs for reuse.
- Web traffic is now allowed only through HTTP and HTTPS from approved IPv4 ranges, while outbound access is limited to HTTP and HTTPS instead of all traffic.
- VPC Flow Logs are enabled by default and sent to CloudWatch so network activity can be reviewed later.
- Public subnets no longer auto-assign public IPs by default, and subnet and access CIDRs are checked for valid format before deployment.

### Impact
`✅ Safer public web access`
`✅ Fewer accidental open-network deployments`
`✅ Clearer network audit trail`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Po097_1n3a4gZLI_QK_tN5EUvn0xGEwsQyiJK6Mjcv4&org=manishcy)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
