### PR TITLE
Add modular AWS VPC networking Terraform config

### DIFF
--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -1,0 +1,57 @@
+# Network Terraform Module
+
+Terraform module to provision:
+- A VPC
+- Two public subnets across two availability zones
+- Two private subnets across two availability zones
+- An internet gateway
+- A single NAT gateway with an Elastic IP
+- Public and private route tables with subnet associations
+- A web security group allowing HTTP and HTTPS
+
+## Requirements
+
+- Terraform `>= 1.5.0`
+- AWS provider `>= 5.0, < 6.0`
+
+## Usage
+
+```hcl
+module "network" {
+  source = "../modules/network"
+
+  name_prefix                = "demo"
+  vpc_cidr_block             = "10.0.0.0/16"
+  availability_zones         = ["us-east-1a", "us-east-1b"]
+  public_subnet_cidr_blocks  = ["10.0.0.0/24", "10.0.1.0/24"]
+  private_subnet_cidr_blocks = ["10.0.10.0/24", "10.0.11.0/24"]
+  web_ingress_cidr_blocks    = ["0.0.0.0/0"]
+
+  tags = {
+    Environment = "dev"
+    Project     = "networking"
+  }
+}
+```
+
+## Notes
+
+- The module creates exactly two public subnets and two private subnets.
+- A single NAT gateway is used for both private subnets to keep the design simple and cost-conscious.
+- `web_ingress_cidr_blocks` controls access to ports `80` and `443`.
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| availability_zones | Availability zones used for the subnets. |
+| vpc_id | ID of the VPC. |
+| vpc_cidr_block | CIDR block of the VPC. |
+| public_subnet_ids | IDs of the public subnets in availability zone order. |
+| private_subnet_ids | IDs of the private subnets in availability zone order. |
+| internet_gateway_id | ID of the internet gateway. |
+| nat_gateway_id | ID of the NAT gateway. |
+| nat_gateway_public_ip | Public IP attached to the NAT gateway. |
+| public_route_table_id | ID of the public route table. |
+| private_route_table_ids | Private route table IDs keyed by availability zone. |
+| web_security_group_id | ID of the web security group. |

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,0 +1,155 @@
+locals {
+  subnet_configuration = {
+    for index, availability_zone in var.availability_zones : availability_zone => {
+      index               = index
+      public_cidr_block   = var.public_subnet_cidr_blocks[index]
+      private_cidr_block  = var.private_subnet_cidr_blocks[index]
+      public_subnet_name  = format("%s-public-%s", var.name_prefix, availability_zone)
+      private_subnet_name = format("%s-private-%s", var.name_prefix, availability_zone)
+      private_route_name  = format("%s-private-rt-%s", var.name_prefix, availability_zone)
+    }
+  }
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr_block
+  enable_dns_support   = var.enable_dns_support
+  enable_dns_hostnames = var.enable_dns_hostnames
+
+  tags = merge(var.tags, var.vpc_tags, {
+    Name = format("%s-vpc", var.name_prefix)
+  })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, var.internet_gateway_tags, {
+    Name = format("%s-igw", var.name_prefix)
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = local.subnet_configuration
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = each.value.public_cidr_block
+  availability_zone       = each.key
+  map_public_ip_on_launch = var.map_public_ip_on_launch
+
+  tags = merge(var.tags, var.public_subnet_tags, {
+    Name = each.value.public_subnet_name
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = local.subnet_configuration
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = each.value.private_cidr_block
+  availability_zone = each.key
+
+  tags = merge(var.tags, var.private_subnet_tags, {
+    Name = each.value.private_subnet_name
+    Tier = "private"
+  })
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(var.tags, var.nat_gateway_tags, {
+    Name = format("%s-nat-eip", var.name_prefix)
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[var.availability_zones[0]].id
+
+  tags = merge(var.tags, var.nat_gateway_tags, {
+    Name = format("%s-nat", var.name_prefix)
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.tags, var.route_table_tags, {
+    Name = format("%s-public-rt", var.name_prefix)
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  for_each = local.subnet_configuration
+
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags = merge(var.tags, var.route_table_tags, {
+    Name = each.value.private_route_name
+  })
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private[each.key].id
+}
+
+resource "aws_security_group" "web" {
+  name        = format("%s-web-sg", var.name_prefix)
+  description = "Allow HTTP and HTTPS traffic to web servers"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "Allow HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.web_ingress_cidr_blocks
+  }
+
+  ingress {
+    description = "Allow HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.web_ingress_cidr_blocks
+  }
+
+  egress {
+    description      = "Allow all outbound traffic"
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = merge(var.tags, var.security_group_tags, {
+    Name = format("%s-web-sg", var.name_prefix)
+  })
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,54 @@
+output "availability_zones" {
+  description = "Availability zones used for the subnets."
+  value       = var.availability_zones
+}
+
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.this.id
+}
+
+output "vpc_cidr_block" {
+  description = "CIDR block of the VPC."
+  value       = aws_vpc.this.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets in availability zone order."
+  value       = [for availability_zone in var.availability_zones : aws_subnet.public[availability_zone].id]
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets in availability zone order."
+  value       = [for availability_zone in var.availability_zones : aws_subnet.private[availability_zone].id]
+}
+
+output "internet_gateway_id" {
+  description = "ID of the internet gateway."
+  value       = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_id" {
+  description = "ID of the NAT gateway."
+  value       = aws_nat_gateway.this.id
+}
+
+output "nat_gateway_public_ip" {
+  description = "Public IP address attached to the NAT gateway."
+  value       = aws_eip.nat.public_ip
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table."
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_ids" {
+  description = "Private route table IDs keyed by availability zone."
+  value       = { for availability_zone, route_table in aws_route_table.private : availability_zone => route_table.id }
+}
+
+output "web_security_group_id" {
+  description = "ID of the web security group."
+  value       = aws_security_group.web.id
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,111 @@
+variable "name_prefix" {
+  description = "Prefix used when naming AWS resources."
+  type        = string
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+}
+
+variable "availability_zones" {
+  description = "Exactly two availability zones used for subnet placement."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.availability_zones) == 2
+    error_message = "availability_zones must contain exactly two availability zones."
+  }
+}
+
+variable "public_subnet_cidr_blocks" {
+  description = "Exactly two CIDR blocks for the public subnets."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.public_subnet_cidr_blocks) == 2
+    error_message = "public_subnet_cidr_blocks must contain exactly two CIDR blocks."
+  }
+}
+
+variable "private_subnet_cidr_blocks" {
+  description = "Exactly two CIDR blocks for the private subnets."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.private_subnet_cidr_blocks) == 2
+    error_message = "private_subnet_cidr_blocks must contain exactly two CIDR blocks."
+  }
+}
+
+variable "map_public_ip_on_launch" {
+  description = "Whether public subnets should automatically assign public IPs to launched instances."
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_support" {
+  description = "Whether DNS support is enabled for the VPC."
+  type        = bool
+  default     = true
+}
+
+variable "enable_dns_hostnames" {
+  description = "Whether instances launched in the VPC receive public DNS hostnames."
+  type        = bool
+  default     = true
+}
+
+variable "web_ingress_cidr_blocks" {
+  description = "CIDR blocks allowed to access the web security group on ports 80 and 443."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  description = "Tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_tags" {
+  description = "Additional tags applied only to the VPC."
+  type        = map(string)
+  default     = {}
+}
+
+variable "public_subnet_tags" {
+  description = "Additional tags applied only to the public subnets."
+  type        = map(string)
+  default     = {}
+}
+
+variable "private_subnet_tags" {
+  description = "Additional tags applied only to the private subnets."
+  type        = map(string)
+  default     = {}
+}
+
+variable "internet_gateway_tags" {
+  description = "Additional tags applied only to the internet gateway."
+  type        = map(string)
+  default     = {}
+}
+
+variable "nat_gateway_tags" {
+  description = "Additional tags applied only to the NAT gateway and its Elastic IP."
+  type        = map(string)
+  default     = {}
+}
+
+variable "route_table_tags" {
+  description = "Additional tags applied only to the route tables."
+  type        = map(string)
+  default     = {}
+}
+
+variable "security_group_tags" {
+  description = "Additional tags applied only to the web security group."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 5.0.0, < 6.0.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,15 @@
-resource "aws_security_group" "bad_sg" {
-  name = "bad_sg"
+locals {
+  selected_availability_zones = var.availability_zones != null ? var.availability_zones : slice(data.aws_availability_zones.available.names, 0, 2)
+}
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]  # ❌ insecure
-  }
+module "network" {
+  source = "../modules/network"
+
+  name_prefix                = var.name_prefix
+  vpc_cidr_block             = var.vpc_cidr_block
+  availability_zones         = local.selected_availability_zones
+  public_subnet_cidr_blocks  = var.public_subnet_cidr_blocks
+  private_subnet_cidr_blocks = var.private_subnet_cidr_blocks
+  web_ingress_cidr_blocks    = var.web_ingress_cidr_blocks
+  tags                       = var.tags
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,49 @@
+output "availability_zones" {
+  description = "Availability zones used by the network module."
+  value       = module.network.availability_zones
+}
+
+output "vpc_id" {
+  description = "ID of the created VPC."
+  value       = module.network.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the created public subnets."
+  value       = module.network.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the created private subnets."
+  value       = module.network.private_subnet_ids
+}
+
+output "internet_gateway_id" {
+  description = "ID of the internet gateway attached to the VPC."
+  value       = module.network.internet_gateway_id
+}
+
+output "nat_gateway_id" {
+  description = "ID of the NAT gateway used by the private subnets."
+  value       = module.network.nat_gateway_id
+}
+
+output "nat_gateway_public_ip" {
+  description = "Public IP address attached to the NAT gateway."
+  value       = module.network.nat_gateway_public_ip
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table."
+  value       = module.network.public_route_table_id
+}
+
+output "private_route_table_ids" {
+  description = "Private route table IDs keyed by availability zone."
+  value       = module.network.private_route_table_ids
+}
+
+output "web_security_group_id" {
+  description = "ID of the security group intended for web servers."
+  value       = module.network.web_security_group_id
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,25 @@
+aws_region = "us-east-1"
+
+name_prefix = "demo"
+
+vpc_cidr_block = "10.0.0.0/16"
+
+public_subnet_cidr_blocks = [
+  "10.0.0.0/24",
+  "10.0.1.0/24",
+]
+
+private_subnet_cidr_blocks = [
+  "10.0.10.0/24",
+  "10.0.11.0/24",
+]
+
+web_ingress_cidr_blocks = [
+  "0.0.0.0/0",
+]
+
+tags = {
+  Environment = "dev"
+  Project     = "networking"
+  ManagedBy   = "Terraform"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,64 @@
+variable "aws_region" {
+  description = "AWS region where resources will be created."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name_prefix" {
+  description = "Prefix used when naming AWS resources."
+  type        = string
+  default     = "web"
+}
+
+variable "vpc_cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "Optional list of exactly two availability zones. When null, the first two available AZs in the region are used."
+  type        = list(string)
+  default     = null
+
+  validation {
+    condition     = var.availability_zones == null || length(var.availability_zones) == 2
+    error_message = "availability_zones must be null or contain exactly two availability zones."
+  }
+}
+
+variable "public_subnet_cidr_blocks" {
+  description = "Exactly two CIDR blocks for the public subnets."
+  type        = list(string)
+  default     = ["10.0.0.0/24", "10.0.1.0/24"]
+
+  validation {
+    condition     = length(var.public_subnet_cidr_blocks) == 2
+    error_message = "public_subnet_cidr_blocks must contain exactly two CIDR blocks."
+  }
+}
+
+variable "private_subnet_cidr_blocks" {
+  description = "Exactly two CIDR blocks for the private subnets."
+  type        = list(string)
+  default     = ["10.0.10.0/24", "10.0.11.0/24"]
+
+  validation {
+    condition     = length(var.private_subnet_cidr_blocks) == 2
+    error_message = "private_subnet_cidr_blocks must contain exactly two CIDR blocks."
+  }
+}
+
+variable "web_ingress_cidr_blocks" {
+  description = "CIDR blocks allowed to access the web security group on ports 80 and 443."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  description = "Tags applied to all resources."
+  type        = map(string)
+  default = {
+    ManagedBy = "Terraform"
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the insecure placeholder root Terraform config with a reusable AWS network composition
- add a `modules/network` module that provisions a VPC, 2 public subnets, 2 private subnets, an internet gateway, a NAT gateway, route tables, and a web security group
- add root variables, outputs, a provider lockfile, and a `terraform.tfvars.example` for easier customization

## Testing
- ✅ `/tmp/terraform-bin/terraform fmt -check -recursive`
- ✅ `/tmp/terraform-bin/terraform init -backend=false`
- ✅ `/tmp/terraform-bin/terraform validate`
- ⚠️ `/tmp/terraform-bin/terraform plan -input=false -refresh=false -var='availability_zones=["us-east-1a","us-east-1b"]'` (blocked by missing AWS credentials in the cloud environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a2b84d2-e0ca-48b7-a11a-d6c2152f1f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a2b84d2-e0ca-48b7-a11a-d6c2152f1f11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

