### PR TITLE
Add modular Terraform AWS network stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin/
+terraform/.terraform/

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,0 +1,155 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  selected_azs = length(var.azs) == 2 ? var.azs : slice(data.aws_availability_zones.available.names, 0, 2)
+  common_tags  = merge(var.tags, { Project = var.project_name, ManagedBy = "Terraform" })
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-vpc"
+  })
+
+  lifecycle {
+    precondition {
+      condition     = length(local.selected_azs) == 2
+      error_message = "At least 2 availability zones are required for this module."
+    }
+  }
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-igw"
+  })
+}
+
+resource "aws_subnet" "public" {
+  count = 2
+
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidrs[count.index]
+  availability_zone       = local.selected_azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-public-${count.index + 1}"
+    Tier = "public"
+  })
+}
+
+resource "aws_subnet" "private" {
+  count = 2
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = var.private_subnet_cidrs[count.index]
+  availability_zone = local.selected_azs[count.index]
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-private-${count.index + 1}"
+    Tier = "private"
+  })
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  depends_on = [aws_internet_gateway.this]
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-nat-eip"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-nat"
+  })
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-public-rt"
+  })
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  count = 2
+
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-private-rt"
+  })
+}
+
+resource "aws_route" "private_nat_access" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this.id
+}
+
+resource "aws_route_table_association" "private" {
+  count = 2
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_security_group" "web" {
+  name        = "${var.project_name}-web-sg"
+  description = "Allow HTTP and HTTPS traffic"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "HTTP from allowed CIDRs"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_web_cidrs
+  }
+
+  ingress {
+    description = "HTTPS from allowed CIDRs"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_web_cidrs
+  }
+
+  egress {
+    description = "Allow all outbound traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${var.project_name}-web-sg"
+  })
+}

--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -1,0 +1,44 @@
+output "vpc_id" {
+  description = "ID of the created VPC."
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets."
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets."
+  value       = aws_subnet.private[*].id
+}
+
+output "internet_gateway_id" {
+  description = "ID of the internet gateway."
+  value       = aws_internet_gateway.this.id
+}
+
+output "nat_gateway_id" {
+  description = "ID of the NAT gateway."
+  value       = aws_nat_gateway.this.id
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table."
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  description = "ID of the private route table."
+  value       = aws_route_table.private.id
+}
+
+output "web_security_group_id" {
+  description = "ID of the web server security group."
+  value       = aws_security_group.web.id
+}
+
+output "availability_zones" {
+  description = "Availability zones used by the module."
+  value       = local.selected_azs
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,56 @@
+variable "project_name" {
+  description = "Prefix used for naming resources."
+  type        = string
+  default     = "web-network"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "azs" {
+  description = "Exactly two availability zones to use. Leave empty to auto-select the first two in the region."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.azs) == 0 || length(var.azs) == 2
+    error_message = "azs must be empty or contain exactly 2 availability zones."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "Two CIDR blocks for public subnets, one per availability zone."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == 2
+    error_message = "public_subnet_cidrs must contain exactly 2 CIDR blocks."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "Two CIDR blocks for private subnets, one per availability zone."
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+
+  validation {
+    condition     = length(var.private_subnet_cidrs) == 2
+    error_message = "private_subnet_cidrs must contain exactly 2 CIDR blocks."
+  }
+}
+
+variable "allowed_web_cidrs" {
+  description = "CIDR ranges allowed to access web ports (HTTP/HTTPS)."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  description = "Tags applied to all resources."
+  type        = map(string)
+  default     = {}
+}

--- a/modules/network/versions.tf
+++ b/modules/network/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 5.0.0, < 6.0.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,15 @@
-resource "aws_security_group" "bad_sg" {
-  name = "bad_sg"
+provider "aws" {
+  region = var.aws_region
+}
 
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]  # ❌ insecure
-  }
+module "network" {
+  source = "../modules/network"
+
+  project_name         = var.project_name
+  vpc_cidr             = var.vpc_cidr
+  azs                  = var.azs
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
+  allowed_web_cidrs    = var.allowed_web_cidrs
+  tags                 = var.tags
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,39 @@
+output "vpc_id" {
+  description = "ID of the created VPC."
+  value       = module.network.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets."
+  value       = module.network.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets."
+  value       = module.network.private_subnet_ids
+}
+
+output "internet_gateway_id" {
+  description = "ID of the internet gateway."
+  value       = module.network.internet_gateway_id
+}
+
+output "nat_gateway_id" {
+  description = "ID of the NAT gateway."
+  value       = module.network.nat_gateway_id
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table."
+  value       = module.network.public_route_table_id
+}
+
+output "private_route_table_id" {
+  description = "ID of the private route table."
+  value       = module.network.private_route_table_id
+}
+
+output "web_security_group_id" {
+  description = "ID of the web server security group."
+  value       = module.network.web_security_group_id
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,18 @@
+aws_region = "us-east-1"
+
+project_name = "web-network"
+vpc_cidr     = "10.0.0.0/16"
+
+# Optional: leave empty to auto-select the first two AZs in the chosen region.
+azs = []
+
+public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+private_subnet_cidrs = ["10.0.101.0/24", "10.0.102.0/24"]
+
+allowed_web_cidrs = ["0.0.0.0/0"]
+
+tags = {
+  Environment = "dev"
+  Terraform   = "true"
+  Project     = "web-network"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,65 @@
+variable "aws_region" {
+  description = "AWS region where resources are created."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "project_name" {
+  description = "Prefix used for naming resources."
+  type        = string
+  default     = "web-network"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "azs" {
+  description = "Exactly two availability zones to use. Leave empty to auto-select first two."
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition     = length(var.azs) == 0 || length(var.azs) == 2
+    error_message = "azs must be empty or contain exactly 2 availability zones."
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "Two CIDR blocks for public subnets."
+  type        = list(string)
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+
+  validation {
+    condition     = length(var.public_subnet_cidrs) == 2
+    error_message = "public_subnet_cidrs must contain exactly 2 CIDR blocks."
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "Two CIDR blocks for private subnets."
+  type        = list(string)
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+
+  validation {
+    condition     = length(var.private_subnet_cidrs) == 2
+    error_message = "private_subnet_cidrs must contain exactly 2 CIDR blocks."
+  }
+}
+
+variable "allowed_web_cidrs" {
+  description = "CIDR ranges allowed to access HTTP/HTTPS."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "tags" {
+  description = "Common tags applied to all resources."
+  type        = map(string)
+  default = {
+    Environment = "dev"
+    Terraform   = "true"
+  }
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 6.0"
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a reusable `modules/network` Terraform module that provisions a VPC, two public subnets, two private subnets, an internet gateway, a NAT gateway, route tables, subnet associations, and a web security group allowing HTTP/HTTPS
- replace `terraform/main.tf` with a clean root module invocation and add root-level `variables.tf`, `outputs.tf`, and `versions.tf`
- add `terraform/terraform.tfvars.example` for easy customization and commit `terraform/.terraform.lock.hcl` for provider version pinning
- add `.gitignore` entries to ignore local Terraform working directory and temporary local tooling binaries

## Testing
- `/workspace/bin/terraform fmt -recursive`
- `/workspace/bin/terraform init -backend=false` (from `terraform/`)
- `/workspace/bin/terraform validate` (from `terraform/`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d86ff848-8f07-4b37-8c97-ed7abb73c6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d86ff848-8f07-4b37-8c97-ed7abb73c6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

